### PR TITLE
Allow use as library by compiling out the entrypoint with `LIBKHAX_AS_LIB`

### DIFF
--- a/main.c
+++ b/main.c
@@ -24,6 +24,7 @@ s32 dump_chunk_wrapper()
 	return 0;
 }
 
+#ifndef LIBKHAX_AS_LIB
 int main()
 {
 	// Initialize services
@@ -82,3 +83,4 @@ int main()
 	// Return to hbmenu
 	return 0;
 }
+#endif


### PR DESCRIPTION
This is especially useful with git submodules, where you cannot easily modify the original repository to, say, remove `main.c`.
